### PR TITLE
Remove MaintenanceWrapper from the main render tree

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -32,7 +32,6 @@ import { AuthCallback } from './components/auth/AuthCallback'
 import { DiscordRedirect } from './components/shared/DiscordRedirect'
 import StaffDashboard from './pages/StaffDashboard.jsx'
 import { ErrorBoundary, RouteError } from './components/shared/ErrorBoundary'
-import MaintenanceWrapper from './components/shared/MaintenanceWrapper'
 
 const router = createBrowserRouter([
   {
@@ -199,14 +198,12 @@ const router = createBrowserRouter([
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <MaintenanceWrapper>
-      <AuthProvider>
-        <ModalProvider>
-          <ErrorBoundary>
-            <RouterProvider router={router} />
-          </ErrorBoundary>
-        </ModalProvider>
-      </AuthProvider>
-    </MaintenanceWrapper>
+    <AuthProvider>
+      <ModalProvider>
+        <ErrorBoundary>
+          <RouterProvider router={router} />
+        </ErrorBoundary>
+      </ModalProvider>
+    </AuthProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
This pull request makes a small change to the application by removing the `MaintenanceWrapper` component from the `src/main.jsx` file. This simplifies the component hierarchy in the application's root rendering logic.

Key change:

* Removed the `MaintenanceWrapper` component from the import statement and the root rendering tree in `src/main.jsx`, indicating that maintenance-related functionality is no longer required or has been relocated. [[1]](diffhunk://#diff-752aae33033979082689dba3e7f51955013615f0535c21ac94265e067da311edL35) [[2]](diffhunk://#diff-752aae33033979082689dba3e7f51955013615f0535c21ac94265e067da311edL202-L210)