### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/stopbars/Website/security/code-scanning/1](https://github.com/stopbars/Website/security/code-scanning/1)

To fix the issue, a `permissions` key should be added to the workflow to explicitly define the least privileges required. Since the workflow mainly involves reading the repository contents and running tests, `contents: read` is sufficient. Add the `permissions` key at the root of the workflow to apply it to all jobs. This ensures that the `GITHUB_TOKEN` used in the workflow has only the specified permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
